### PR TITLE
Issue #9: Adding CPU speed support

### DIFF
--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/compute/DimensionDataCloudControllerComputeServiceAdapter.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/compute/DimensionDataCloudControllerComputeServiceAdapter.java
@@ -16,21 +16,11 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.compute;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-import static java.lang.String.format;
-import static org.jclouds.compute.reference.ComputeServiceConstants.COMPUTE_LOGGER;
-import static org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils.generateFirewallRuleName;
-import static org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils.generatePortListName;
-import static org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils.simplifyPorts;
-
-import java.util.List;
-
-import javax.annotation.Resource;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
+import com.google.common.base.Objects;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.Image;
@@ -51,17 +41,26 @@ import org.jclouds.dimensiondata.cloudcontroller.domain.NetworkInfo;
 import org.jclouds.dimensiondata.cloudcontroller.domain.OsImage;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Placement;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Response;
+import org.jclouds.dimensiondata.cloudcontroller.domain.factory.CpuFactory;
 import org.jclouds.dimensiondata.cloudcontroller.domain.internal.ServerWithExternalIp;
 import org.jclouds.dimensiondata.cloudcontroller.domain.options.CreateServerOptions;
 import org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils;
 import org.jclouds.domain.LoginCredentials;
 import org.jclouds.logging.Logger;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static org.jclouds.compute.reference.ComputeServiceConstants.COMPUTE_LOGGER;
+import static org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils.generateFirewallRuleName;
+import static org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils.generatePortListName;
+import static org.jclouds.dimensiondata.cloudcontroller.utils.DimensionDataCloudControllerUtils.simplifyPorts;
 
 /**
  * defines the connection between the {@link org.jclouds.dimensiondata.cloudcontroller.DimensionDataCloudControllerApi} implementation and
@@ -137,6 +136,7 @@ public class DimensionDataCloudControllerComputeServiceAdapter implements
 
         CreateServerOptions createServerOptions = CreateServerOptions.builder()
                 .memoryGb(template.getHardware().getRam() / 1024)
+                .cpu(new CpuFactory().create(template.getHardware().getProcessors()))
                 .build();
 
         Response deployServerResponse = api.getServerApi().deployServer(ORG_ID, name, imageId, Boolean.TRUE, networkInfo, disks, loginPassword, createServerOptions);

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/compute/functions/OsImageToHardware.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/compute/functions/OsImageToHardware.java
@@ -16,19 +16,21 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.compute.functions;
 
-import javax.inject.Singleton;
-
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.HardwareBuilder;
 import org.jclouds.compute.domain.Processor;
 import org.jclouds.compute.domain.Volume;
 import org.jclouds.compute.domain.VolumeBuilder;
+import org.jclouds.dimensiondata.cloudcontroller.domain.CPU;
+import org.jclouds.dimensiondata.cloudcontroller.domain.CpuSpeed;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Disk;
 import org.jclouds.dimensiondata.cloudcontroller.domain.OsImage;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
 
 @Singleton
 public class OsImageToHardware implements Function<OsImage, Hardware> {
@@ -36,26 +38,35 @@ public class OsImageToHardware implements Function<OsImage, Hardware> {
    @Override
    public Hardware apply(final OsImage from) {
       HardwareBuilder builder = new HardwareBuilder().ids(from.id())
-              .name(from.name())
-              .hypervisor("vmx")
-              .processors(ImmutableList.of(new Processor(from.cpu().count(), from.cpu().coresPerSocket())))
-              .ram(from.memoryGb() * 1024);
+            .name(from.name())
+            .hypervisor("vmx")
+            .processors(buildProcessorList(from.cpu()))
+            .ram(from.memoryGb() * 1024);
 
       if (from.disks() != null) {
          builder.volumes(
-                 FluentIterable.from(from.disks())
-                         .transform(new Function<Disk, Volume>() {
-                            @Override
-                            public Volume apply(Disk disk) {
-                               return new VolumeBuilder()
-                                       .id(disk.id())
-                                       .device(String.valueOf(disk.scsiId()))
-                                       .size(Float.valueOf(disk.sizeGb()))
-                                       .type(Volume.Type.LOCAL)
-                                       .build();
-                            }
-                         }).toSet());
+               FluentIterable.from(from.disks())
+                     .transform(new Function<Disk, Volume>() {
+            @Override
+            public Volume apply(Disk disk) {
+               return new VolumeBuilder()
+                     .id(disk.id())
+                     .device(String.valueOf(disk.scsiId()))
+                     .size(Float.valueOf(disk.sizeGb()))
+                     .type(Volume.Type.LOCAL)
+                     .build();
+            }
+         }).toSet());
       }
       return builder.build();
+   }
+
+   private List<Processor> buildProcessorList(final CPU cpu) {
+      final List<Processor> processorList = new ArrayList<Processor>();
+      final double speed = CpuSpeed.fromDimensionDataSpeed(cpu.speed()).getJCloudsSpeed();
+      for (int count = 0; count < cpu.count(); count++) {
+         processorList.add(new Processor(cpu.coresPerSocket(), speed));
+      }
+      return processorList;
    }
 }

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeed.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeed.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.dimensiondata.cloudcontroller.domain;
+
+/**
+ * Defines the CPU speeds available in the Dimension Data Cloud.
+ */
+public enum CpuSpeed {
+
+   /**
+    * Dimension Data Economy speed CPU.
+    * <p/>
+    * May not be available in all datacenters.
+    */
+   ECONOMY(200),
+
+   /**
+    * Dimension Data Standard speed CPU.
+    * <p/>
+    * The default CPU speed if not otherwise specified.
+    */
+   STANDARD(339),
+
+   /**
+    * Dimension Data High-Performance speed CPU.
+    * <p/>
+    * May not be available in all datacenters.
+    */
+   HIGHPERFORMANCE(800);
+
+   /**
+    * The values used to represent this CPU speed in JClouds.
+    */
+   private final double jCloudsSpeed;
+
+   CpuSpeed(double jCloudsSpeed) {
+      this.jCloudsSpeed = jCloudsSpeed;
+   }
+
+   /**
+    * Gets the default CPU speed used in the Dimension Data cloud.
+    *
+    * @return the default speed.
+    */
+   public static CpuSpeed getDefaultCpuSpeed() {
+      return STANDARD;
+   }
+
+   /**
+    * Gets the CPU speed that corresponds to the supplied required speed.
+    * <p/>
+    * If there is no matching speed for the supplied value then the {@link #getDefaultCpuSpeed()} speed is returned.
+    *
+    * @param requiredSpeed the CPU speed that is required.
+    * @return the corresponding CPU speed.
+    */
+   public static CpuSpeed fromJCloudsSpeed(final double requiredSpeed) {
+      for (CpuSpeed cpuSpeed : CpuSpeed.values()) {
+         if (cpuSpeed.jCloudsSpeed == requiredSpeed) {
+            return cpuSpeed;
+         }
+      }
+      return getDefaultCpuSpeed();
+   }
+
+   /**
+    * Gets the CPU speed that corresponds to the supplied required speed.
+    * <p/>
+    * If there is no matching speed for the supplied value then the {@link #getDefaultCpuSpeed()} speed is returned.
+    *
+    * @param requiredSpeed the CPU speed that is required.
+    * @return the corresponding CPU speed.
+    */
+   public static CpuSpeed fromDimensionDataSpeed(final String requiredSpeed) {
+      for (CpuSpeed cpuSpeed : CpuSpeed.values()) {
+         if (cpuSpeed.getDimensionDataSpeed().equals(requiredSpeed)) {
+            return cpuSpeed;
+         }
+      }
+      return getDefaultCpuSpeed();
+   }
+
+   /**
+    * Gets the CPU speed as represented in JClouds.
+    *
+    * @return the CPU speed.
+    */
+   public double getJCloudsSpeed() {
+      return jCloudsSpeed;
+   }
+
+   /**
+    * Gets the CPU speed as represented in the Dimension Data cloud.
+    *
+    * @return the CPU speed.
+    */
+   public String getDimensionDataSpeed() {
+      return name();
+   }
+}

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/factory/CpuFactory.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/factory/CpuFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.dimensiondata.cloudcontroller.domain.factory;
+
+import org.jclouds.compute.domain.Processor;
+import org.jclouds.dimensiondata.cloudcontroller.domain.CPU;
+import org.jclouds.dimensiondata.cloudcontroller.domain.CpuSpeed;
+
+import java.util.List;
+
+public class CpuFactory {
+
+   /**
+    * Creates a CPU instance for the supplied processor list.
+    * <p/>
+    * The {@link CpuSpeed#getDefaultCpuSpeed()} speed will be selected by default if invalid input is supplied, eg:
+    * <ul>
+    * <li>Differing speed values across processors - this is not valid in the Dimension Data cloud.</li>
+    * <li>Invalid speed value found that is not mapped in {@link CpuSpeed}.</li>
+    * </ul>
+    * <p/>
+    * The value of coresPerSocket will be set to 1 if invalid input is supplied, eg:
+    * <ul>
+    * <li>Differing cores values across processors - this is not valid in the Dimension Data cloud.</li>
+    * </ul>
+    * <p/>
+    * If the processor list is empty, then a {@link CpuSpeed#getDefaultCpuSpeed()} speed CPU with 1 core is assumed.
+    *
+    * @param processorList the input processor list - may be empty.
+    * @return CPU instance representing the supplied processor list.
+    */
+   public CPU create(final List<? extends Processor> processorList) {
+      return CPU.builder().count(processorList.isEmpty() ? 1 : processorList.size())
+            .speed(determineDimensionDataCpuSpeed(processorList)).coresPerSocket(determineCoresPerSocket(processorList))
+            .build();
+   }
+
+   private String determineDimensionDataCpuSpeed(final List<? extends Processor> processorList) {
+      if (processorList.isEmpty()) {
+         return CpuSpeed.getDefaultCpuSpeed().getDimensionDataSpeed();
+      } else {
+         final double firstUserSuppliedSpeed = processorList.get(0).getSpeed();
+
+         for (Processor processor : processorList) {
+            if (processor.getSpeed() != firstUserSuppliedSpeed) {
+               return CpuSpeed.getDefaultCpuSpeed().getDimensionDataSpeed();
+            }
+         }
+         return CpuSpeed.fromJCloudsSpeed(firstUserSuppliedSpeed).getDimensionDataSpeed();
+      }
+   }
+
+   private int determineCoresPerSocket(final List<? extends Processor> processorList) {
+      if (processorList.isEmpty()) {
+         return 1;
+      } else {
+         final double firstUserSuppliedCores = processorList.get(0).getCores();
+         for (Processor processor : processorList) {
+            if (processor.getCores() != firstUserSuppliedCores) {
+               return 1;
+            }
+         }
+         return (int) firstUserSuppliedCores;
+      }
+   }
+}

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/compute/DimensionDataCloudControllerComputeServiceContextLiveTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/compute/DimensionDataCloudControllerComputeServiceContextLiveTest.java
@@ -16,16 +16,8 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.compute;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.jclouds.compute.predicates.NodePredicates.inGroup;
-import static org.jclouds.compute.predicates.NodePredicates.runningInGroup;
-
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Resource;
-import javax.inject.Named;
-
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Module;
 import org.jclouds.compute.RunNodesException;
 import org.jclouds.compute.RunScriptOnNodesException;
 import org.jclouds.compute.domain.ExecResponse;
@@ -42,8 +34,14 @@ import org.jclouds.sshj.config.SshjSshClientModule;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Module;
+import javax.annotation.Resource;
+import javax.inject.Named;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jclouds.compute.predicates.NodePredicates.inGroup;
+import static org.jclouds.compute.predicates.NodePredicates.runningInGroup;
 
 @Test(groups = "live", testName = "DimensionDataCloudControllerComputeServiceContextLiveTest")
 public class DimensionDataCloudControllerComputeServiceContextLiveTest extends BaseComputeServiceContextLiveTest {

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeedTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeedTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.dimensiondata.cloudcontroller.domain;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "unit", testName = "CpuSpeedTest") public class CpuSpeedTest {
+
+   public void getDefaultCpuSpeedReturnsStandardSpeed() {
+      assertEquals(CpuSpeed.getDefaultCpuSpeed(), CpuSpeed.STANDARD);
+   }
+
+   public void getFromJCloudsSpeed() {
+      assertEquals(CpuSpeed.fromJCloudsSpeed(200D), CpuSpeed.ECONOMY);
+      assertEquals(CpuSpeed.fromJCloudsSpeed(339D), CpuSpeed.STANDARD);
+      assertEquals(CpuSpeed.fromJCloudsSpeed(800D), CpuSpeed.HIGHPERFORMANCE);
+      assertEquals(CpuSpeed.fromJCloudsSpeed(123D), CpuSpeed.getDefaultCpuSpeed());
+   }
+
+   public void getFromDimensionDataSpeed() {
+      assertEquals(CpuSpeed.fromDimensionDataSpeed("ECONOMY"), CpuSpeed.ECONOMY);
+      assertEquals(CpuSpeed.fromDimensionDataSpeed("STANDARD"), CpuSpeed.STANDARD);
+      assertEquals(CpuSpeed.fromDimensionDataSpeed("HIGHPERFORMANCE"), CpuSpeed.HIGHPERFORMANCE);
+      assertEquals(CpuSpeed.fromDimensionDataSpeed("INVALID"), CpuSpeed.getDefaultCpuSpeed());
+   }
+}

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/factory/CpuFactoryTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/factory/CpuFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.dimensiondata.cloudcontroller.domain.factory;
+
+import org.jclouds.compute.domain.Processor;
+import org.jclouds.dimensiondata.cloudcontroller.domain.CPU;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+@Test(groups = "unit", testName = "CpuFactoryTest")
+public class CpuFactoryTest {
+
+   private static final double ECONOMY_SPEED = 200D;
+   private static final double HIGHPERFORMANCE_SPEED = 800D;
+   private static final double INVALID_SPEED = 666D;
+   private static final double TWO_CORES = 2D;
+   private static final double FOUR_CORES = 4D;
+
+   private CpuFactory factory = new CpuFactory();
+
+   public void singleProcessor() {
+      final CPU cpu = factory.create(Collections.singletonList(new Processor(TWO_CORES, ECONOMY_SPEED)));
+      assertEquals((int) cpu.count(), 1);
+      assertEquals(cpu.speed(), "ECONOMY");
+      assertEquals((int) cpu.coresPerSocket(), 2);
+   }
+
+   public void multipleIdenticalProcessors() {
+      final Processor processor1 = new Processor(TWO_CORES, ECONOMY_SPEED);
+      final Processor processor2 = new Processor(TWO_CORES, ECONOMY_SPEED);
+      List<Processor> processorList = new ArrayList<Processor>();
+      processorList.add(processor1);
+      processorList.add(processor2);
+
+      final CPU cpu = factory.create(processorList);
+      assertEquals((int) cpu.count(), 2);
+      assertEquals(cpu.speed(), "ECONOMY");
+      assertEquals((int) cpu.coresPerSocket(), 2);
+   }
+
+   public void inconsistentProcessorSpeedsMeansDefaultSpeedUsed() {
+      final Processor processor1 = new Processor(TWO_CORES, ECONOMY_SPEED);
+      final Processor processor2 = new Processor(TWO_CORES, HIGHPERFORMANCE_SPEED);
+      List<Processor> processorList = new ArrayList<Processor>();
+      processorList.add(processor1);
+      processorList.add(processor2);
+
+      final CPU cpu = factory.create(processorList);
+      assertEquals((int) cpu.count(), 2);
+      assertEquals(cpu.speed(), "STANDARD");
+      assertEquals((int) cpu.coresPerSocket(), 2);
+   }
+
+   public void inconsistentProcessorCoresMeansDefaultCoresUsed() {
+      final Processor processor1 = new Processor(TWO_CORES, ECONOMY_SPEED);
+      final Processor processor2 = new Processor(FOUR_CORES, ECONOMY_SPEED);
+      List<Processor> processorList = new ArrayList<Processor>();
+      processorList.add(processor1);
+      processorList.add(processor2);
+
+      final CPU cpu = factory.create(processorList);
+      assertEquals((int) cpu.count(), 2);
+      assertEquals(cpu.speed(), "ECONOMY");
+      assertEquals((int) cpu.coresPerSocket(), 1);
+   }
+
+   public void invalidProcessorSpeedMeansDefaultSpeedUsed() {
+      final CPU cpu = factory.create(Collections.singletonList(new Processor(TWO_CORES, INVALID_SPEED)));
+      assertEquals((int) cpu.count(), 1);
+      assertEquals(cpu.speed(), "STANDARD");
+      assertEquals((int) cpu.coresPerSocket(), 2);
+   }
+
+   public void emptyProcessorListMeansDefaultCpuUsed() {
+      final CPU cpu = factory.create(Collections.<Processor>emptyList());
+      assertEquals((int) cpu.count(), 1);
+      assertEquals(cpu.speed(), "STANDARD");
+      assertEquals((int) cpu.coresPerSocket(), 1);
+   }
+
+}

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/features/ServerApiMockTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/features/ServerApiMockTest.java
@@ -16,9 +16,7 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.features;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-
+import com.google.common.collect.Lists;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Disk;
 import org.jclouds.dimensiondata.cloudcontroller.domain.NIC;
 import org.jclouds.dimensiondata.cloudcontroller.domain.NetworkInfo;
@@ -26,7 +24,8 @@ import org.jclouds.dimensiondata.cloudcontroller.domain.Response;
 import org.jclouds.dimensiondata.cloudcontroller.internal.BaseDimensionDataCloudControllerMockTest;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.Lists;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 /**
  * Mock tests for the {@link ServerApi} class.
@@ -35,8 +34,8 @@ import com.google.common.collect.Lists;
 public class ServerApiMockTest extends BaseDimensionDataCloudControllerMockTest {
 
     public void testDeployServerReturnsUnexpectedError() throws InterruptedException {
-        server.enqueue(responseUnexpectedError());
-        server.enqueue(response200());
+       server.enqueue(responseUnexpectedError());
+       server.enqueue(response200());
 
         NetworkInfo networkInfo = NetworkInfo.create(
                 "networkDomainId",
@@ -52,11 +51,41 @@ public class ServerApiMockTest extends BaseDimensionDataCloudControllerMockTest 
                 Lists.<Disk>newArrayList(),
                 "administratorPassword");
 
-        assertNull(response);
+       assertNull(response);
 
         assertEquals(server.getRequestCount(), 2);
         assertSent(server, "POST", "/caas/2.2/" + ORG_ID + "/server/deployServer");
     }
+
+// FIXME - Commented out as seems to be an issue preventing multiple tests working at present.
+//   public void testDeployServerWithSpecificCpu() throws InterruptedException {
+//         server.enqueue(response200());
+//
+//         NetworkInfo networkInfo = NetworkInfo.create(
+//               "networkDomainId",
+//               NIC.builder().vlanId("vlanId").build(),
+//               Lists.<NIC>newArrayList()
+//         );
+//
+//         CreateServerOptions createServerOptions = CreateServerOptions.builder()
+//               .cpu(CPU.builder()
+//                     .count(1)
+//                     .speed("HIGHPERFORMANCE")
+//                     .coresPerSocket(2)
+//                     .build())
+//               .build();
+//         api.getServerApi().deployServer(ORG_ID,
+//               ServerApiMockTest.class.getSimpleName(),
+//               "imageId",
+//               true,
+//               networkInfo,
+//               Lists.<Disk>newArrayList(),
+//               "administratorPassword",
+//               createServerOptions);
+//         RecordedRequest recordedRequest = assertSent(server, "POST", "/caas/2.2/"+ ORG_ID + "/server/deployServer");
+//         assertBodyContains(
+//               recordedRequest, "\"cpu\":{\"count\":1,\"speed\":\"HIGHPERFORMANCE\",\"coresPerSocket\":2}");
+//      }
 
 /*
     public void testGetServerReturnsResourceNotFound() throws InterruptedException {

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/internal/BaseDimensionDataCloudControllerMockTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/internal/BaseDimensionDataCloudControllerMockTest.java
@@ -16,16 +16,6 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.internal;
 
-import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.util.Properties;
-import java.util.Set;
-
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-
 import org.jclouds.ContextBuilder;
 import org.jclouds.concurrent.config.ExecutorServiceModule;
 import org.jclouds.dimensiondata.cloudcontroller.DimensionDataCloudControllerApi;
@@ -45,6 +35,14 @@ import com.google.inject.Module;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.google.common.util.concurrent.MoreExecutors.sameThreadExecutor;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Base class for all DimensionDataCloudController mock tests.
@@ -158,5 +156,9 @@ private final Set<Module> modules = ImmutableSet.<Module> of(new ExecutorService
       assertThat(request.getPath()).isEqualTo(path);
       assertThat(request.getHeader(HttpHeaders.ACCEPT)).isEqualTo(MediaType.APPLICATION_JSON);
       return request;
+   }
+
+   protected void assertBodyContains(RecordedRequest recordedRequest, String expectedText){
+      assertThat(recordedRequest.getUtf8Body()).contains(expectedText);
    }
 }


### PR DESCRIPTION
My initial attempt at adding CPU speed support....

You'll see I've added an enum that defines the mapping between the jclouds double value for CPU speed, and the Dimension Data string representation. There is also a CpuFactory class that can build CPU instances from Processor instances.
The existing OsImageToHardware function has been modified to convert CPU correctly to the Processor representation.
DimensionDataCloudControllerComputeServiceAdapter modified to include CPU params in call to deploy server.

Added some basic unit tests around the new classes, and a commented-out test in ServerApiMockTest that shows the mapping into the rest call works. Commented for now pending the question I asked on gitter re this testsuite.
