### PR TITLE
filtering on set of Datacenter IDs and Network Domain ID

### DIFF
--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/compute/config/DimensionDataCloudControllerComputeServiceContextModule.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/compute/config/DimensionDataCloudControllerComputeServiceContextModule.java
@@ -16,6 +16,8 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.compute.config;
 
+import javax.inject.Singleton;
+
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceAdapter;
 import org.jclouds.compute.config.ComputeServiceAdapterContextModule;
@@ -40,10 +42,15 @@ import org.jclouds.dimensiondata.cloudcontroller.domain.internal.ServerWithExter
 import org.jclouds.domain.Location;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 
 public class DimensionDataCloudControllerComputeServiceContextModule extends
         ComputeServiceAdapterContextModule<ServerWithExternalIp, OsImage, OsImage, Datacenter> {
+
+    private DimensionDataCloudControllerTemplateOptions templateOptions;
 
     @Override
     protected void configure() {
@@ -68,5 +75,22 @@ public class DimensionDataCloudControllerComputeServiceContextModule extends
         install(new LocationsFromComputeServiceAdapterModule<ServerWithExternalIp, OsImage, OsImage, Datacenter>() {
         });
 
+    }
+
+    @Override
+    protected TemplateOptions provideTemplateOptions(Injector injector, TemplateOptions options) {
+        this.templateOptions = (DimensionDataCloudControllerTemplateOptions) options;
+        return super.provideTemplateOptions(injector, options);
+    }
+
+    @Provides
+    @Singleton
+    protected Supplier<DimensionDataCloudControllerTemplateOptions> getTemplateOptions() {
+        return new Supplier<DimensionDataCloudControllerTemplateOptions>() {
+            @Override
+            public DimensionDataCloudControllerTemplateOptions get() {
+                return templateOptions;
+            }
+        };
     }
 }

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/features/InfrastructureApi.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/features/InfrastructureApi.java
@@ -28,10 +28,11 @@ import org.jclouds.collect.PagedIterable;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Datacenter;
 import org.jclouds.dimensiondata.cloudcontroller.domain.OperatingSystem;
 import org.jclouds.dimensiondata.cloudcontroller.domain.PaginatedCollection;
+import org.jclouds.dimensiondata.cloudcontroller.filters.DatacenterIdListDatacentersFilter;
 import org.jclouds.dimensiondata.cloudcontroller.filters.OrganisationIdFilter;
+import org.jclouds.dimensiondata.cloudcontroller.options.PaginationOptions;
 import org.jclouds.dimensiondata.cloudcontroller.parsers.ParseDatacenters;
 import org.jclouds.dimensiondata.cloudcontroller.parsers.ParseOperatingSystems;
-import org.jclouds.dimensiondata.cloudcontroller.options.PaginationOptions;
 import org.jclouds.http.filters.BasicAuthentication;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.RequestFilters;
@@ -55,6 +56,7 @@ public interface InfrastructureApi {
     @Path("/datacenter")
     @Transform(ParseDatacenters.ToPagedIterable.class)
     @ResponseParser(ParseDatacenters.class)
+    @RequestFilters(DatacenterIdListDatacentersFilter.class)
     @Fallback(Fallbacks.EmptyPagedIterableOnNotFoundOr404.class)
     PagedIterable<Datacenter> listDatacenters();
 

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/features/ServerApi.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/features/ServerApi.java
@@ -30,11 +30,13 @@ import javax.ws.rs.core.MediaType;
 import org.jclouds.Fallbacks;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Disk;
+import org.jclouds.dimensiondata.cloudcontroller.domain.NetworkInfo;
 import org.jclouds.dimensiondata.cloudcontroller.domain.PaginatedCollection;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Response;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Server;
 import org.jclouds.dimensiondata.cloudcontroller.domain.options.CreateServerOptions;
-import org.jclouds.dimensiondata.cloudcontroller.domain.NetworkInfo;
+import org.jclouds.dimensiondata.cloudcontroller.filters.DatacenterIdFilter;
+import org.jclouds.dimensiondata.cloudcontroller.filters.NetworkDomainIdFilter;
 import org.jclouds.dimensiondata.cloudcontroller.filters.OrganisationIdFilter;
 import org.jclouds.dimensiondata.cloudcontroller.options.PaginationOptions;
 import org.jclouds.dimensiondata.cloudcontroller.parsers.ParseServers;
@@ -65,6 +67,7 @@ public interface ServerApi {
     @Transform(ParseServers.ToPagedIterable.class)
     @ResponseParser(ParseServers.class)
     @Fallback(Fallbacks.EmptyPagedIterableOnNotFoundOr404.class)
+    @RequestFilters({DatacenterIdFilter.class, NetworkDomainIdFilter.class})
     PagedIterable<Server> listServers();
 
     @Named("server:get")

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/filters/DatacenterIdFilter.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/filters/DatacenterIdFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.dimensiondata.cloudcontroller.filters;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import com.google.common.base.Supplier;
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpRequestFilter;
+import org.jclouds.location.Zone;
+
+/**
+ * Adds set of Datacenter IDs as set in jclouds.zones JVM property.
+ */
+public class DatacenterIdFilter implements HttpRequestFilter {
+   @Inject @Zone
+   protected Supplier<Set<String>> datacenterIdsSupplier;
+
+   @Override public HttpRequest filter(HttpRequest request) throws HttpException {
+      Set<String> datacenterIds = datacenterIdsSupplier.get();
+      if (datacenterIds != null && !datacenterIds.isEmpty()) {
+         return request.toBuilder().addQueryParam("datacenterId", datacenterIds).build();
+      } else {
+         return request;
+      }
+   }
+}

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/filters/DatacenterIdListDatacentersFilter.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/filters/DatacenterIdListDatacentersFilter.java
@@ -16,25 +16,27 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.filters;
 
-import com.google.common.base.Supplier;
-import org.jclouds.dimensiondata.cloudcontroller.compute.options.DimensionDataCloudControllerTemplateOptions;
-import org.jclouds.http.HttpException;
-import org.jclouds.http.HttpRequest;
-import org.jclouds.http.HttpRequestFilter;
+import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.google.common.base.Supplier;
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpRequestFilter;
+import org.jclouds.location.Zone;
+
 /**
- * Adds Network Domain ID from TemplateOptions to the request.
+ * Adds set of Datacenter IDs as set in jclouds.zones JVM property.
  */
-public class NetworkDomainIdFilter implements HttpRequestFilter {
-   @Inject
-   protected Supplier<DimensionDataCloudControllerTemplateOptions> templateOptionsSupplier;
+public class DatacenterIdListDatacentersFilter implements HttpRequestFilter {
+   @Inject @Zone
+   protected Supplier<Set<String>> datacenterIdsSupplier;
 
    @Override public HttpRequest filter(HttpRequest request) throws HttpException {
-      DimensionDataCloudControllerTemplateOptions templateOptions = templateOptionsSupplier.get();
-      if (templateOptions != null && templateOptions.getNetworkDomainId() != null) {
-         return request.toBuilder().addQueryParam("networkDomainId", templateOptions.getNetworkDomainId()).build();
+      Set<String> datacenterIds = datacenterIdsSupplier.get();
+      if (datacenterIds != null && !datacenterIds.isEmpty()) {
+         return request.toBuilder().addQueryParam("id", datacenterIds).build();
       } else {
          return request;
       }

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/filters/NetworkDomainIdFilter.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/filters/NetworkDomainIdFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jclouds.dimensiondata.cloudcontroller.filters;
+
+import com.google.common.base.Supplier;
+import org.jclouds.dimensiondata.cloudcontroller.compute.options.DimensionDataCloudControllerTemplateOptions;
+import org.jclouds.http.HttpException;
+import org.jclouds.http.HttpRequest;
+import org.jclouds.http.HttpRequestFilter;
+
+import javax.inject.Inject;
+
+/**
+ * Adds Network Domain ID from TemplateOptions to the request.
+ */
+public class NetworkDomainIdFilter implements HttpRequestFilter {
+   @Inject
+   protected Supplier<DimensionDataCloudControllerTemplateOptions> templateOptionsSupplier;
+
+   @Override public HttpRequest filter(HttpRequest request) throws HttpException {
+      DimensionDataCloudControllerTemplateOptions templateOptions = templateOptionsSupplier.get();
+      if (templateOptions.getNetworkDomainId() != null) {
+         return request.toBuilder().addQueryParam("networkDomainId", templateOptions.getNetworkDomainId()).build();
+      } else {
+         return request;
+      }
+   }
+}


### PR DESCRIPTION
List Servers and List Datacenters APIs filter by set of Datacenter IDs and Network Domain ID.
Network Domain ID is set in the TemplateOptions.
Datacenter IDs are set in JVM property clouds.zones (comma separated).

The way TemplateOptions are made available for injection is not very clean, because jclouds-compute assumes that TemplateOptions will only be useful for some operations, but not runScriptOnNodesMatching
