### PR TITLE
Issue #9: Added reconfigure CPU to ServerApi

### DIFF
--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeed.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeed.java
@@ -26,24 +26,27 @@ public enum CpuSpeed {
     * <p/>
     * May not be available in all datacenters.
     */
-   ECONOMY(200),
+   ECONOMY(10),
 
    /**
     * Dimension Data Standard speed CPU.
     * <p/>
     * The default CPU speed if not otherwise specified.
     */
-   STANDARD(339),
+   STANDARD(20),
 
    /**
     * Dimension Data High-Performance speed CPU.
     * <p/>
     * May not be available in all datacenters.
     */
-   HIGHPERFORMANCE(800);
+   HIGHPERFORMANCE(30);
 
    /**
-    * The values used to represent this CPU speed in JClouds.
+    * The value used to represent this CPU speed in JClouds.
+    * <p/>
+    * There is no significance to the numerical value other than ordering of the supported speeds. Values are not
+    * proportional to each other in any way.
     */
    private final double jCloudsSpeed;
 

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/Property.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/domain/Property.java
@@ -16,9 +16,9 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.domain;
 
-import org.jclouds.json.SerializedNames;
-
 import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
 
 @AutoValue
 public abstract class Property {
@@ -26,6 +26,8 @@ public abstract class Property {
     Property() {} // For AutoValue only!
 
     public abstract String name();
+
+    @Nullable
     public abstract String value();
 
     @SerializedNames({ "name", "value" })

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/features/ServerApi.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/features/ServerApi.java
@@ -16,25 +16,14 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.features;
 
-import java.util.List;
-
-import javax.inject.Named;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.jclouds.Fallbacks;
 import org.jclouds.collect.PagedIterable;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Disk;
+import org.jclouds.dimensiondata.cloudcontroller.domain.NetworkInfo;
 import org.jclouds.dimensiondata.cloudcontroller.domain.PaginatedCollection;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Response;
 import org.jclouds.dimensiondata.cloudcontroller.domain.Server;
 import org.jclouds.dimensiondata.cloudcontroller.domain.options.CreateServerOptions;
-import org.jclouds.dimensiondata.cloudcontroller.domain.NetworkInfo;
 import org.jclouds.dimensiondata.cloudcontroller.filters.OrganisationIdFilter;
 import org.jclouds.dimensiondata.cloudcontroller.options.PaginationOptions;
 import org.jclouds.dimensiondata.cloudcontroller.parsers.ParseServers;
@@ -46,6 +35,16 @@ import org.jclouds.rest.annotations.RequestFilters;
 import org.jclouds.rest.annotations.ResponseParser;
 import org.jclouds.rest.annotations.Transform;
 import org.jclouds.rest.binders.BindToJsonPayload;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
 
 @RequestFilters({BasicAuthentication.class, OrganisationIdFilter.class})
 @Consumes(MediaType.APPLICATION_JSON)
@@ -111,5 +110,14 @@ public interface ServerApi {
     @Produces(MediaType.APPLICATION_JSON)
     @MapBinder(BindToJsonPayload.class)
     Response rebootServerServer(@PayloadParam("id") String id);
+
+    @Named("server:reconfigureServer")
+    @POST
+    @Path("/reconfigureServer")
+    @Produces(MediaType.APPLICATION_JSON)
+    @MapBinder(BindToJsonPayload.class)
+    Response reconfigureServer(@PayloadParam("id") String id,
+          @PayloadParam("cpuCount") int cpuCount, @PayloadParam("cpuSpeed") String cpuSpeed,
+          @PayloadParam("coresPerSocket") int coresPerSocket);
 
 }

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/handlers/DimensionDataCloudControllerErrorHandler.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/handlers/DimensionDataCloudControllerErrorHandler.java
@@ -16,10 +16,6 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.handlers;
 
-import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
-
-import javax.inject.Singleton;
-
 import org.jclouds.http.HttpCommand;
 import org.jclouds.http.HttpErrorHandler;
 import org.jclouds.http.HttpResponse;
@@ -27,6 +23,10 @@ import org.jclouds.http.HttpResponseException;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.rest.ResourceAlreadyExistsException;
 import org.jclouds.rest.ResourceNotFoundException;
+
+import javax.inject.Singleton;
+
+import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
 
 /**
  * This will org.jclouds.dimensiondata.cloudcontroller.parse and set an appropriate exception on the command object.
@@ -49,7 +49,9 @@ public class DimensionDataCloudControllerErrorHandler implements HttpErrorHandle
                     exception = new ResourceNotFoundException(message, exception);
                 } else if (message.contains("INVALID_INPUT_DATA") ||
                         message.contains("ORGANIZATION_NOT_VERIFIED") ||
-                        message.contains("SYSTEM_ERROR") && !message.contains("RETRYABLE_SYSTEM_ERROR")) {
+                        message.contains("SYSTEM_ERROR") && !message.contains("RETRYABLE_SYSTEM_ERROR") ||
+                        message.contains("CPU_SPEED_NOT_AVAILABLE") ||
+                        message.contains("CONFIGURATION_NOT_SUPPORTED")) {
                     exception = new IllegalStateException(message, exception);
                 } else if (message.contains("RESOURCE_BUSY") || message.contains("UNEXPECTED_ERROR")) {
                     exception = new ResourceNotFoundException(message, exception);

--- a/src/main/java/org/jclouds/dimensiondata/cloudcontroller/handlers/DimensionDataCloudControllerRetryHandler.java
+++ b/src/main/java/org/jclouds/dimensiondata/cloudcontroller/handlers/DimensionDataCloudControllerRetryHandler.java
@@ -16,20 +16,19 @@
  */
 package org.jclouds.dimensiondata.cloudcontroller.handlers;
 
-import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
-import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
-
-import javax.annotation.Resource;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
 import org.jclouds.http.HttpCommand;
 import org.jclouds.http.HttpResponse;
 import org.jclouds.http.handlers.BackoffLimitedRetryHandler;
 import org.jclouds.logging.Logger;
 
-import com.google.common.annotations.Beta;
-import com.google.inject.Inject;
+import javax.annotation.Resource;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import static org.jclouds.Constants.PROPERTY_MAX_RETRIES;
+import static org.jclouds.http.HttpUtils.closeClientButKeepContentStream;
 
 /**
  * Retry handler that takes into account the DimensionData retriers and delays
@@ -61,7 +60,11 @@ public class DimensionDataCloudControllerRetryHandler extends BackoffLimitedRetr
          return false;
       } else if (command.getFailureCount() > retryCountLimit) {
          logger.error("Cannot retry after server error, command has exceeded retry limit %1$d: %2$s", retryCountLimit,
-                 command);
+               command);
+         return false;
+      } else if (response.getStatusCode() == 400 && (
+            message.contains("CPU_SPEED_NOT_AVAILABLE") ||
+            message.contains("CONFIGURATION_NOT_SUPPORTED"))) {
          return false;
       } else {
          imposeBackoffExponentialDelay(command.getFailureCount(), "server error: " + command.toString());

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/compute/DimensionDataCloudControllerComputeServiceContextLiveTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/compute/DimensionDataCloudControllerComputeServiceContextLiveTest.java
@@ -27,6 +27,7 @@ import org.jclouds.compute.domain.OsFamily;
 import org.jclouds.compute.domain.Template;
 import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.compute.reference.ComputeServiceConstants;
+import org.jclouds.dimensiondata.cloudcontroller.DimensionDataCloudControllerApi;
 import org.jclouds.dimensiondata.cloudcontroller.compute.options.DimensionDataCloudControllerTemplateOptions;
 import org.jclouds.logging.Logger;
 import org.jclouds.scriptbuilder.statements.login.AdminAccess;
@@ -42,6 +43,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jclouds.compute.predicates.NodePredicates.inGroup;
 import static org.jclouds.compute.predicates.NodePredicates.runningInGroup;
+import static org.testng.Assert.assertNotNull;
 
 @Test(groups = "live", testName = "DimensionDataCloudControllerComputeServiceContextLiveTest")
 public class DimensionDataCloudControllerComputeServiceContextLiveTest extends BaseComputeServiceContextLiveTest {
@@ -55,6 +57,7 @@ public class DimensionDataCloudControllerComputeServiceContextLiveTest extends B
     public DimensionDataCloudControllerComputeServiceContextLiveTest() {
         provider = "dimensiondata-cloudcontroller";
     }
+
 
     @Test
     public void testListHardwareProfiles() {
@@ -113,7 +116,23 @@ public class DimensionDataCloudControllerComputeServiceContextLiveTest extends B
         } finally {
             view.getComputeService().destroyNodesMatching(inGroup(name));
         }
-}
+    }
+
+    @Test
+    public void testUnwrapToDimensionDataApi(){
+        DimensionDataCloudControllerApi dimensionDataCloudControllerApi =
+              view.unwrapApi(DimensionDataCloudControllerApi.class);
+        assertNotNull(dimensionDataCloudControllerApi);
+    }
+
+    @Test
+    public void reconfigureServerCpu(){
+        DimensionDataCloudControllerApi dimensionDataCloudControllerApi =
+                      view.unwrapApi(DimensionDataCloudControllerApi.class);
+        dimensionDataCloudControllerApi.getServerApi()
+              // server ID corresponds to "GJ_Test" server in devlab1
+              .reconfigureServer("4e00b8f7-28ea-4103-b757-0aa7f3a94e1e", 1, "STANDARD", 1);
+    }
 
     @Override
     protected Iterable<Module> setupModules() {

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeedTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/CpuSpeedTest.java
@@ -20,17 +20,18 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 
-@Test(groups = "unit", testName = "CpuSpeedTest") public class CpuSpeedTest {
+@Test(groups = "unit", testName = "CpuSpeedTest")
+public class CpuSpeedTest {
 
    public void getDefaultCpuSpeedReturnsStandardSpeed() {
       assertEquals(CpuSpeed.getDefaultCpuSpeed(), CpuSpeed.STANDARD);
    }
 
    public void getFromJCloudsSpeed() {
-      assertEquals(CpuSpeed.fromJCloudsSpeed(200D), CpuSpeed.ECONOMY);
-      assertEquals(CpuSpeed.fromJCloudsSpeed(339D), CpuSpeed.STANDARD);
-      assertEquals(CpuSpeed.fromJCloudsSpeed(800D), CpuSpeed.HIGHPERFORMANCE);
-      assertEquals(CpuSpeed.fromJCloudsSpeed(123D), CpuSpeed.getDefaultCpuSpeed());
+      assertEquals(CpuSpeed.fromJCloudsSpeed(10D), CpuSpeed.ECONOMY);
+      assertEquals(CpuSpeed.fromJCloudsSpeed(20D), CpuSpeed.STANDARD);
+      assertEquals(CpuSpeed.fromJCloudsSpeed(30D), CpuSpeed.HIGHPERFORMANCE);
+      assertEquals(CpuSpeed.fromJCloudsSpeed(666D), CpuSpeed.getDefaultCpuSpeed());
    }
 
    public void getFromDimensionDataSpeed() {

--- a/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/factory/CpuFactoryTest.java
+++ b/src/test/java/org/jclouds/dimensiondata/cloudcontroller/domain/factory/CpuFactoryTest.java
@@ -29,8 +29,8 @@ import static org.testng.Assert.assertEquals;
 @Test(groups = "unit", testName = "CpuFactoryTest")
 public class CpuFactoryTest {
 
-   private static final double ECONOMY_SPEED = 200D;
-   private static final double HIGHPERFORMANCE_SPEED = 800D;
+   private static final double ECONOMY_SPEED = 10D;
+   private static final double HIGHPERFORMANCE_SPEED = 30D;
    private static final double INVALID_SPEED = 666D;
    private static final double TWO_CORES = 2D;
    private static final double FOUR_CORES = 4D;


### PR DESCRIPTION
Few little things in here...
- Changed the numbers being used for the CPU speeds to 10, 20 & 30 and updated javadoc to make it clear they mean nothing other than ordering the CPU speeds
- Think I figured out from looking at one of @trevorflanagan commits what the problem with ServerApiMockTest was - missing a singleThreaded attribute in the test NG annotation - seems to get past the problem.
- Added new ServerApi method for reconfiguring the CPU speed. This can be accessed by unwrapping the DD API, have a live test showing it working against devlab1.
